### PR TITLE
fix: adjusted nav link config to specifiy an href to avoid always bei…

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -48,7 +48,7 @@ import { Logo } from '../config'
                         href={item.href.startsWith('http') ? item.href : import.meta.env.BASE_URL + item.href}
                         target={item.target ? item.target : "_self"}
                         class={
-                          ((item.href.length > 0 && Astro.url.toString().includes(item.href)) || item.children?.some((child) => Astro.url.toString().includes(child.href))
+                          (((item.href && item.href !== '#' && item.href !== '' && Astro.url.toString().includes(item.href)) || item.children?.some((child) => Astro.url.toString().includes(child.href)))
                             ? 'bg-orange text-spruce dark:bg-orange-500'
                             : 'text-spruce hover:bg-orange-500 hover:text-spruce dark:text-orange dark:hover:bg-orange-800 dark:hover:text-spruce') +
                           ' rounded-md px-2 py-2 text-lg font-medium inline-flex items-center'
@@ -155,7 +155,7 @@ import { Logo } from '../config'
                 href={item.href.startsWith('http') ? item.href : import.meta.env.BASE_URL + item.href}
                 target={item.target ? item.target : "_self"}
                 class={
-                  ((item.href.length > 0 && Astro.url.toString().includes(item.href)) || item.children?.some((child) => Astro.url.toString().includes(child.href))
+                  (((item.href && item.href !== '#' && item.href !== '' && Astro.url.toString().includes(item.href)) || item.children?.some((child) => Astro.url.toString().includes(child.href)))
                     ? 'bg-orange text-spruce dark:bg-orange-500'
                     : 'text-spruce hover:bg-orange-500 hover:text-spruce dark:text-orange dark:hover:bg-orange-800 dark:hover:text-spruce') +
                   ' rounded-md px-2 py-2 text-lg font-medium inline-flex items-center'

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,7 @@ export { default as DefaultImage } from './assets/undraw/undraw_my_feed.png'
 export const NavigationLinks = [
   { name: 'Home', href: '', target: '_self' },
   { name: 'About', href: 'about', target: '_self' },
-  { name: 'Solutions', href: '', target: '', children:
+  { name: 'Solutions', href: '#', target: '', children:
     [
       { name: 'Hub', href: 'hub', target: '_self' },
       { name: 'Fusion', href: 'fusion', target: '_self' }


### PR DESCRIPTION
Found issue with navigation active styles for new 'Solutions' navigation header.

Since I never specified an `href` value for the parent, it was always being considered active.

Adjusted the configuration to use `#` since there is no 'solutions' page, and then updated the header component to take the `#` into account.